### PR TITLE
feat: add home page with dynamic cart

### DIFF
--- a/app/Livewire/CartSummary.php
+++ b/app/Livewire/CartSummary.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class CartSummary extends Component
+{
+    public array $cart = [];
+    public float $subtotal = 0.0;
+    public float $shipping = 0.0;
+    public int $loyaltyPoints = 0;
+    public ?array $coupon = null;
+    public string $couponCode = '';
+
+    protected $listeners = ['addToCart' => 'add', 'applyCoupon' => 'applyCoupon'];
+
+    public function mount()
+    {
+        $this->recalculate();
+    }
+
+    public function add(array $product): void
+    {
+        $id = $product['id'];
+        if (isset($this->cart[$id])) {
+            $this->cart[$id]['qty']++;
+        } else {
+            $this->cart[$id] = [
+                'id' => $id,
+                'name' => $product['name'],
+                'price' => $product['price'],
+                'qty' => 1,
+            ];
+        }
+
+        $this->recalculate();
+    }
+
+    public function applyCoupon(string $code): void
+    {
+        // Stubbed coupon logic for demonstration
+        $this->coupon = ['code' => $code, 'discount' => $code === 'SAVE10' ? 0.10 : 0];
+        $this->recalculate();
+    }
+
+    protected function recalculate(): void
+    {
+        $this->subtotal = collect($this->cart)->sum(fn($item) => $item['price'] * $item['qty']);
+        $this->loyaltyPoints = (int) floor($this->subtotal / 10);
+        $this->shipping = $this->subtotal > 100 ? 0 : 10;
+    }
+
+    public function getTotalProperty(): float
+    {
+        $discount = $this->coupon['discount'] ?? 0;
+        return round($this->subtotal - ($this->subtotal * $discount) + $this->shipping, 2);
+    }
+
+    public function render()
+    {
+        return view('livewire.cart-summary');
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,60 @@
+<x-app-layout>
+    <div class="py-8">
+        <div class="max-w-7xl mx-auto px-4">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+                @php
+                    $products = [
+                        ['id' => 1, 'name' => 'Espresso', 'price' => 3.50, 'image' => 'https://source.unsplash.com/random/300x300?espresso'],
+                        ['id' => 2, 'name' => 'Cappuccino', 'price' => 4.25, 'image' => 'https://source.unsplash.com/random/300x300?cappuccino'],
+                        ['id' => 3, 'name' => 'Latte', 'price' => 4.75, 'image' => 'https://source.unsplash.com/random/300x300?latte'],
+                        ['id' => 4, 'name' => 'Mocha', 'price' => 5.00, 'image' => 'https://source.unsplash.com/random/300x300?mocha'],
+                    ];
+                    $preferencesSaved = session('preferences_saved', false);
+                @endphp
+                @foreach($products as $product)
+                    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden flex flex-col">
+                        <img src="{{ $product['image'] }}" alt="{{ $product['name'] }}" class="h-48 w-full object-cover">
+                        <div class="p-4 flex-1 flex flex-col">
+                            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ $product['name'] }}</h3>
+                            <p class="mt-1 text-gray-600 dark:text-gray-300">${{ number_format($product['price'],2) }}</p>
+                            <div class="mt-auto space-x-2">
+                                <button onclick="Livewire.dispatch('addToCart', {id: {{ $product['id'] }}, name: '{{ $product['name'] }}', price: {{ $product['price'] }}})" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">Add to Cart</button>
+                                @if($preferencesSaved)
+                                    <button class="mt-4 px-4 py-2 bg-green-600 text-white rounded">Buy Now</button>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    </div>
+
+    <div class="fixed bottom-6 right-6 w-80">
+        <livewire:cart-summary />
+    </div>
+
+    <div id="exit-modal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center">
+        <div class="bg-white dark:bg-gray-800 p-6 rounded shadow text-center">
+            <h2 class="text-xl font-semibold">Wait!</h2>
+            <p class="mt-2">{{ auth()->user()?->name ? 'Hey '.auth()->user()->name.',' : '' }} take 10% off with code <span class="font-bold">SAVE10</span></p>
+            <button id="close-exit-modal" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">Continue Shopping</button>
+        </div>
+    </div>
+
+    <script>
+        const exitModal = document.getElementById('exit-modal');
+        const closeExitModal = document.getElementById('close-exit-modal');
+        let exitShown = false;
+        document.addEventListener('mouseleave', e => {
+            if (e.clientY <= 0 && !exitShown) {
+                exitModal.classList.remove('hidden');
+                exitModal.classList.add('flex');
+                exitShown = true;
+            }
+        });
+        closeExitModal.addEventListener('click', () => {
+            exitModal.classList.add('hidden');
+        });
+    </script>
+</x-app-layout>

--- a/resources/views/livewire/cart-summary.blade.php
+++ b/resources/views/livewire/cart-summary.blade.php
@@ -1,0 +1,26 @@
+<div class="bg-white dark:bg-gray-800 shadow rounded p-4 text-gray-800 dark:text-gray-100">
+    <h3 class="text-lg font-semibold mb-2">Cart Summary</h3>
+    <ul class="space-y-1">
+        @forelse($cart as $item)
+            <li class="flex justify-between text-sm">
+                <span>{{ $item['name'] }} x {{ $item['qty'] }}</span>
+                <span>${{ number_format($item['price'] * $item['qty'], 2) }}</span>
+            </li>
+        @empty
+            <li class="text-sm text-gray-500">Your cart is empty.</li>
+        @endforelse
+    </ul>
+    <div class="mt-4 border-t pt-2 text-sm space-y-1">
+        <div class="flex justify-between"><span>Subtotal</span><span>${{ number_format($subtotal,2) }}</span></div>
+        <div class="flex justify-between"><span>Shipping</span><span>${{ number_format($shipping,2) }}</span></div>
+        @if($coupon)
+            <div class="flex justify-between text-green-600"><span>Coupon ({{ $coupon['code'] }})</span><span>-{{ $coupon['discount'] * 100 }}%</span></div>
+        @endif
+        <div class="flex justify-between font-semibold"><span>Total</span><span>${{ number_format($this->total,2) }}</span></div>
+        <div class="mt-2 text-xs text-gray-500">Loyalty points: {{ $loyaltyPoints }}</div>
+    </div>
+    <div class="mt-3 flex">
+        <input type="text" wire:model.defer="couponCode" placeholder="Coupon code" class="flex-1 rounded-l border-gray-300" />
+        <button wire:click="applyCoupon($couponCode)" class="px-3 py-2 bg-blue-600 text-white rounded-r">Apply</button>
+    </div>
+</div>

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -37,34 +37,41 @@ new class extends Component
             </div>
 
             <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
-                <x-dropdown align="right" width="48">
-                    <x-slot name="trigger">
-                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 focus:outline-none transition ease-in-out duration-150">
-                            <div x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></div>
+            @auth
+                <div class="hidden sm:flex sm:items-center sm:ms-6">
+                    <x-dropdown align="right" width="48">
+                        <x-slot name="trigger">
+                            <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 dark:text-gray-400 bg-white dark:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-300 focus:outline-none transition ease-in-out duration-150">
+                                <div x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></div>
 
-                            <div class="ms-1">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                </svg>
-                            </div>
-                        </button>
-                    </x-slot>
+                                <div class="ms-1">
+                                    <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+                                        <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+                                    </svg>
+                                </div>
+                            </button>
+                        </x-slot>
 
-                    <x-slot name="content">
-                        <x-dropdown-link :href="route('profile')" wire:navigate>
-                            {{ __('Profile') }}
-                        </x-dropdown-link>
-
-                        <!-- Authentication -->
-                        <button wire:click="logout" class="w-full text-start">
-                            <x-dropdown-link>
-                                {{ __('Log Out') }}
+                        <x-slot name="content">
+                            <x-dropdown-link :href="route('profile')" wire:navigate>
+                                {{ __('Profile') }}
                             </x-dropdown-link>
-                        </button>
-                    </x-slot>
-                </x-dropdown>
-            </div>
+
+                            <!-- Authentication -->
+                            <button wire:click="logout" class="w-full text-start">
+                                <x-dropdown-link>
+                                    {{ __('Log Out') }}
+                                </x-dropdown-link>
+                            </button>
+                        </x-slot>
+                    </x-dropdown>
+                </div>
+            @else
+                <div class="hidden sm:flex sm:items-center sm:ms-6 space-x-4">
+                    <a href="{{ route('login') }}" class="text-sm text-gray-700 dark:text-gray-300" wire:navigate>{{ __('Log in') }}</a>
+                    <a href="{{ route('register') }}" class="text-sm text-gray-700 dark:text-gray-300" wire:navigate>{{ __('Register') }}</a>
+                </div>
+            @endauth
 
             <!-- Hamburger -->
             <div class="-me-2 flex items-center sm:hidden">
@@ -87,24 +94,37 @@ new class extends Component
         </div>
 
         <!-- Responsive Settings Options -->
-        <div class="pt-4 pb-1 border-t border-gray-200 dark:border-gray-600">
-            <div class="px-4">
-                <div class="font-medium text-base text-gray-800 dark:text-gray-200" x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></div>
-                <div class="font-medium text-sm text-gray-500">{{ auth()->user()->email }}</div>
-            </div>
+        @auth
+            <div class="pt-4 pb-1 border-t border-gray-200 dark:border-gray-600">
+                <div class="px-4">
+                    <div class="font-medium text-base text-gray-800 dark:text-gray-200" x-data="{{ json_encode(['name' => auth()->user()->name]) }}" x-text="name" x-on:profile-updated.window="name = $event.detail.name"></div>
+                    <div class="font-medium text-sm text-gray-500">{{ auth()->user()->email }}</div>
+                </div>
 
-            <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('profile')" wire:navigate>
-                    {{ __('Profile') }}
-                </x-responsive-nav-link>
-
-                <!-- Authentication -->
-                <button wire:click="logout" class="w-full text-start">
-                    <x-responsive-nav-link>
-                        {{ __('Log Out') }}
+                <div class="mt-3 space-y-1">
+                    <x-responsive-nav-link :href="route('profile')" wire:navigate>
+                        {{ __('Profile') }}
                     </x-responsive-nav-link>
-                </button>
+
+                    <!-- Authentication -->
+                    <button wire:click="logout" class="w-full text-start">
+                        <x-responsive-nav-link>
+                            {{ __('Log Out') }}
+                        </x-responsive-nav-link>
+                    </button>
+                </div>
             </div>
-        </div>
+        @else
+            <div class="pt-4 pb-1 border-t border-gray-200 dark:border-gray-600">
+                <div class="mt-3 space-y-1">
+                    <x-responsive-nav-link :href="route('login')" wire:navigate>
+                        {{ __('Log in') }}
+                    </x-responsive-nav-link>
+                    <x-responsive-nav-link :href="route('register')" wire:navigate>
+                        {{ __('Register') }}
+                    </x-responsive-nav-link>
+                </div>
+            </div>
+        @endauth
     </div>
 </nav>


### PR DESCRIPTION
## Summary
- add responsive home page with Tailwind product grid and buy-now
- implement livewire cart summary with coupon, shipping, and points
- handle guest navigation links for login/register and exit intent modal

## Testing
- `npm run build`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b16dbd7f00832e9e71461ff3cacc8d