### PR TITLE
Add sticky category navigation and infinite-scroll product listing

### DIFF
--- a/app/Livewire/ProductList.php
+++ b/app/Livewire/ProductList.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Component;
+
+class ProductList extends Component
+{
+    public array $products = [];
+    public int $perPage = 4;
+
+    protected array $allProducts = [];
+
+    public function mount(): void
+    {
+        $this->allProducts = [
+            ['id' => 1, 'slug' => 'espresso', 'name' => 'Espresso', 'price' => 3.50, 'image' => 'https://source.unsplash.com/random/300x300?espresso', 'category' => 'coffee'],
+            ['id' => 2, 'slug' => 'cappuccino', 'name' => 'Cappuccino', 'price' => 4.25, 'image' => 'https://source.unsplash.com/random/300x300?cappuccino', 'category' => 'coffee'],
+            ['id' => 3, 'slug' => 'latte', 'name' => 'Latte', 'price' => 4.75, 'image' => 'https://source.unsplash.com/random/300x300?latte', 'category' => 'coffee'],
+            ['id' => 4, 'slug' => 'mocha', 'name' => 'Mocha', 'price' => 5.00, 'image' => 'https://source.unsplash.com/random/300x300?mocha', 'category' => 'coffee'],
+            ['id' => 5, 'slug' => 'green-tea', 'name' => 'Green Tea', 'price' => 2.50, 'image' => 'https://source.unsplash.com/random/300x300?greentea', 'category' => 'tea'],
+            ['id' => 6, 'slug' => 'black-tea', 'name' => 'Black Tea', 'price' => 2.75, 'image' => 'https://source.unsplash.com/random/300x300?blacktea', 'category' => 'tea'],
+            ['id' => 7, 'slug' => 'french-press', 'name' => 'French Press', 'price' => 25.00, 'image' => 'https://source.unsplash.com/random/300x300?frenchpress', 'category' => 'equipment'],
+            ['id' => 8, 'slug' => 'coffee-grinder', 'name' => 'Coffee Grinder', 'price' => 45.00, 'image' => 'https://source.unsplash.com/random/300x300?grinder', 'category' => 'equipment'],
+        ];
+        $this->products = array_slice($this->allProducts, 0, $this->perPage);
+    }
+
+    public function loadMore(): void
+    {
+        $this->perPage += 4;
+        $this->products = array_slice($this->allProducts, 0, $this->perPage);
+    }
+
+    public function getHasMoreProperty(): bool
+    {
+        return $this->perPage < count($this->allProducts);
+    }
+
+    public function render()
+    {
+        return view('livewire.product-list');
+    }
+}

--- a/config/categories.php
+++ b/config/categories.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    ['slug' => 'coffee', 'name' => 'Coffee'],
+    ['slug' => 'tea', 'name' => 'Tea'],
+    ['slug' => 'equipment', 'name' => 'Equipment'],
+];
+

--- a/resources/views/category.blade.php
+++ b/resources/views/category.blade.php
@@ -1,0 +1,15 @@
+<x-app-layout>
+    <div class="py-8">
+        <div class="max-w-7xl mx-auto px-4">
+            <nav class="mb-4 text-sm text-gray-500" aria-label="Breadcrumb">
+                <ol class="list-reset flex">
+                    <li><a href="{{ route('home') }}" class="text-blue-600">Home</a></li>
+                    <li class="mx-2">/</li>
+                    <li class="text-gray-700 capitalize">{{ $category }}</li>
+                </ol>
+            </nav>
+            <h1 class="text-2xl font-semibold capitalize">{{ $category }} Category</h1>
+            <!-- Category product list would go here -->
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,32 +1,7 @@
 <x-app-layout>
     <div class="py-8">
         <div class="max-w-7xl mx-auto px-4">
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                @php
-                    $products = [
-                        ['id' => 1, 'name' => 'Espresso', 'price' => 3.50, 'image' => 'https://source.unsplash.com/random/300x300?espresso'],
-                        ['id' => 2, 'name' => 'Cappuccino', 'price' => 4.25, 'image' => 'https://source.unsplash.com/random/300x300?cappuccino'],
-                        ['id' => 3, 'name' => 'Latte', 'price' => 4.75, 'image' => 'https://source.unsplash.com/random/300x300?latte'],
-                        ['id' => 4, 'name' => 'Mocha', 'price' => 5.00, 'image' => 'https://source.unsplash.com/random/300x300?mocha'],
-                    ];
-                    $preferencesSaved = session('preferences_saved', false);
-                @endphp
-                @foreach($products as $product)
-                    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden flex flex-col">
-                        <img src="{{ $product['image'] }}" alt="{{ $product['name'] }}" class="h-48 w-full object-cover">
-                        <div class="p-4 flex-1 flex flex-col">
-                            <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">{{ $product['name'] }}</h3>
-                            <p class="mt-1 text-gray-600 dark:text-gray-300">${{ number_format($product['price'],2) }}</p>
-                            <div class="mt-auto space-x-2">
-                                <button onclick="Livewire.dispatch('addToCart', {id: {{ $product['id'] }}, name: '{{ $product['name'] }}', price: {{ $product['price'] }}})" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">Add to Cart</button>
-                                @if($preferencesSaved)
-                                    <button class="mt-4 px-4 py-2 bg-green-600 text-white rounded">Buy Now</button>
-                                @endif
-                            </div>
-                        </div>
-                    </div>
-                @endforeach
-            </div>
+            <livewire:product-list />
         </div>
     </div>
 

--- a/resources/views/livewire/layout/navigation.blade.php
+++ b/resources/views/livewire/layout/navigation.blade.php
@@ -16,7 +16,7 @@ new class extends Component
     }
 }; ?>
 
-<nav x-data="{ open: false }" class="bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700">
+<nav x-data="{ open: false }" class="sticky top-0 z-10 bg-white dark:bg-gray-800 border-b border-gray-100 dark:border-gray-700">
     <!-- Primary Navigation Menu -->
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">
@@ -28,11 +28,20 @@ new class extends Component
                     </a>
                 </div>
 
+                @php
+                    $categories = config('categories', []);
+                    $currentCategory = request()->route('category');
+                @endphp
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    @foreach($categories as $category)
+                        <x-nav-link :href="route('categories.show', $category['slug'])" :active="$currentCategory === $category['slug']" wire:navigate>
+                            {{ $category['name'] }}
+                        </x-nav-link>
+                    @endforeach
                 </div>
             </div>
 
@@ -91,6 +100,11 @@ new class extends Component
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')" wire:navigate>
                 {{ __('Dashboard') }}
             </x-responsive-nav-link>
+            @foreach($categories as $category)
+                <x-responsive-nav-link :href="route('categories.show', $category['slug'])" :active="$currentCategory === $category['slug']" wire:navigate>
+                    {{ $category['name'] }}
+                </x-responsive-nav-link>
+            @endforeach
         </div>
 
         <!-- Responsive Settings Options -->

--- a/resources/views/livewire/product-list.blade.php
+++ b/resources/views/livewire/product-list.blade.php
@@ -1,0 +1,29 @@
+<div>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        @php $preferencesSaved = session('preferences_saved', false); @endphp
+        @foreach($products as $product)
+            <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden flex flex-col">
+                <a href="{{ route('products.show', [$product['category'], $product['slug']]) }}" wire:navigate>
+                    <img src="{{ $product['image'] }}" alt="{{ $product['name'] }}" class="h-48 w-full object-cover">
+                </a>
+                <div class="p-4 flex-1 flex flex-col">
+                    <h3 class="text-lg font-medium text-gray-900 dark:text-gray-100">
+                        <a href="{{ route('products.show', [$product['category'], $product['slug']]) }}" wire:navigate>{{ $product['name'] }}</a>
+                    </h3>
+                    <p class="mt-1 text-gray-600 dark:text-gray-300">${{ number_format($product['price'],2) }}</p>
+                    <div class="mt-auto space-x-2">
+                        <button onclick="Livewire.dispatch('addToCart', {id: {{ $product['id'] }}, name: '{{ $product['name'] }}', price: {{ $product['price'] }}})" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">Add to Cart</button>
+                        @if($preferencesSaved)
+                            <button class="mt-4 px-4 py-2 bg-green-600 text-white rounded">Buy Now</button>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+    @if($this->hasMore)
+        <div class="mt-6 text-center">
+            <button wire:click="loadMore" class="px-4 py-2 bg-blue-600 text-white rounded">Load More</button>
+        </div>
+    @endif
+</div>

--- a/resources/views/product.blade.php
+++ b/resources/views/product.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <div class="py-8">
+        <div class="max-w-7xl mx-auto px-4">
+            <nav class="mb-4 text-sm text-gray-500" aria-label="Breadcrumb">
+                <ol class="list-reset flex">
+                    <li><a href="{{ route('home') }}" class="text-blue-600">Home</a></li>
+                    <li class="mx-2">/</li>
+                    <li><a href="{{ route('categories.show', $category) }}" class="text-blue-600 capitalize">{{ $category }}</a></li>
+                    <li class="mx-2">/</li>
+                    <li class="text-gray-700 capitalize">{{ $product }}</li>
+                </ol>
+            </nav>
+            <h1 class="text-2xl font-semibold capitalize">{{ $product }}</h1>
+            <!-- Product details would go here -->
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,15 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::view('/', 'home');
+Route::view('/', 'home')->name('home');
+
+Route::get('/categories/{category}', function (string $category) {
+    return view('category', ['category' => $category]);
+})->name('categories.show');
+
+Route::get('/categories/{category}/products/{product}', function (string $category, string $product) {
+    return view('product', ['category' => $category, 'product' => $product]);
+})->name('products.show');
 
 Route::view('dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])


### PR DESCRIPTION
## Summary
- make navigation sticky and show active product categories
- add breadcrumb trails for category and product pages
- implement Livewire product list with load-more infinite scroll

## Testing
- `npm test` *(fails: Missing script "test")*
- `vendor/bin/pest` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b16ffabc50832e92cdb012764c38ac