### PR TITLE
Add interactive product gallery with rotation, color preview, and zoom

### DIFF
--- a/resources/views/components/product-gallery.blade.php
+++ b/resources/views/components/product-gallery.blade.php
@@ -1,0 +1,64 @@
+@props(['images' => [], 'colors' => []])
+
+<div {{ $attributes->merge(['class' => 'product-gallery']) }} data-images='@json($images)' data-colors='@json($colors)'>
+    <div class="relative overflow-hidden w-full h-full">
+        <img class="pg-image w-full h-full object-cover cursor-grab" src="{{ $images[0] ?? '' }}" alt="">
+    </div>
+    @if(!empty($colors))
+        <div class="flex space-x-2 mt-2">
+            @foreach($colors as $color => $frames)
+                <button class="pg-color w-6 h-6 rounded-full border" data-color="{{ $color }}" style="background-color: {{ $color }}"></button>
+            @endforeach
+        </div>
+    @endif
+</div>
+
+@once
+    <script src="https://unpkg.com/medium-zoom@1.0.6/dist/medium-zoom.min.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            document.querySelectorAll('.product-gallery').forEach(function (gallery) {
+                let frames = JSON.parse(gallery.dataset.images || '[]');
+                const colorData = JSON.parse(gallery.dataset.colors || '{}');
+                let currentFrames = frames;
+                let index = 0;
+                const img = gallery.querySelector('.pg-image');
+                let dragging = false;
+                let startX = 0;
+                if (img && window.mediumZoom) {
+                    mediumZoom(img);
+                }
+                img?.addEventListener('mousedown', function (e) {
+                    dragging = true;
+                    startX = e.clientX;
+                    e.preventDefault();
+                });
+                img?.addEventListener('mouseup', function () {
+                    dragging = false;
+                });
+                img?.addEventListener('mouseleave', function () {
+                    dragging = false;
+                });
+                img?.addEventListener('mousemove', function (e) {
+                    if (!dragging || currentFrames.length === 0) return;
+                    const dx = e.clientX - startX;
+                    if (Math.abs(dx) > 5) {
+                        index = (index + (dx > 0 ? 1 : -1) + currentFrames.length) % currentFrames.length;
+                        img.src = currentFrames[index];
+                        startX = e.clientX;
+                    }
+                });
+                gallery.querySelectorAll('.pg-color').forEach(function (btn) {
+                    btn.addEventListener('click', function () {
+                        const color = btn.dataset.color;
+                        if (colorData[color]) {
+                            currentFrames = colorData[color];
+                            index = 0;
+                            img.src = currentFrames[0];
+                        }
+                    });
+                });
+            });
+        });
+    </script>
+@endonce

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,6 +1,25 @@
 <x-app-layout>
     <div class="py-8">
         <div class="max-w-7xl mx-auto px-4">
+            <h2 class="text-2xl font-semibold mb-4">Featured Items</h2>
+            @php
+                $featured1 = [
+                    'https://via.placeholder.com/600?text=Featured+1-1',
+                    'https://via.placeholder.com/600?text=Featured+1-2',
+                    'https://via.placeholder.com/600?text=Featured+1-3',
+                    'https://via.placeholder.com/600?text=Featured+1-4',
+                ];
+                $featured2 = [
+                    'https://via.placeholder.com/600?text=Featured+2-1',
+                    'https://via.placeholder.com/600?text=Featured+2-2',
+                    'https://via.placeholder.com/600?text=Featured+2-3',
+                    'https://via.placeholder.com/600?text=Featured+2-4',
+                ];
+            @endphp
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
+                <x-product-gallery :images="$featured1" />
+                <x-product-gallery :images="$featured2" />
+            </div>
             <livewire:product-list />
         </div>
     </div>

--- a/resources/views/product.blade.php
+++ b/resources/views/product.blade.php
@@ -11,6 +11,30 @@
                 </ol>
             </nav>
             <h1 class="text-2xl font-semibold capitalize">{{ $product }}</h1>
+            @php
+                $frames = [
+                    "https://via.placeholder.com/800?text={$product}+1",
+                    "https://via.placeholder.com/800?text={$product}+2",
+                    "https://via.placeholder.com/800?text={$product}+3",
+                    "https://via.placeholder.com/800?text={$product}+4",
+                ];
+                $colors = [
+                    '#ff0000' => [
+                        "https://via.placeholder.com/800/ff0000?text={$product}+red1",
+                        "https://via.placeholder.com/800/ff0000?text={$product}+red2",
+                        "https://via.placeholder.com/800/ff0000?text={$product}+red3",
+                        "https://via.placeholder.com/800/ff0000?text={$product}+red4",
+                    ],
+                    '#0000ff' => [
+                        "https://via.placeholder.com/800/0000ff?text={$product}+blue1",
+                        "https://via.placeholder.com/800/0000ff?text={$product}+blue2",
+                        "https://via.placeholder.com/800/0000ff?text={$product}+blue3",
+                        "https://via.placeholder.com/800/0000ff?text={$product}+blue4",
+                    ],
+                ];
+            @endphp
+
+            <x-product-gallery :images="$frames" :colors="$colors" class="mt-6 max-w-md" />
             <!-- Product details would go here -->
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add reusable product-gallery Blade component with 360° rotation, color switching, and zoom support
- embed product gallery in product detail view
- showcase product gallery on the home page with featured items

## Testing
- `npm run build`
- `composer test` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b1711197e0832e8752441dd77d65be