### PR TITLE
Add one-click checkout with stored user preferences

### DIFF
--- a/app/Livewire/CheckoutForm.php
+++ b/app/Livewire/CheckoutForm.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\UserPreference;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class CheckoutForm extends Component
+{
+    public array $shipping = [
+        'address' => '',
+        'city' => '',
+        'postal_code' => '',
+    ];
+
+    public array $payment = [
+        'card_last_four' => '',
+        'token' => '',
+    ];
+
+    public string $errorMessage = '';
+
+    public ?UserPreference $preference = null;
+
+    public function mount(): void
+    {
+        $this->preference = Auth::user()?->preference;
+
+        if (request()->boolean('oneclick')) {
+            $this->fillFromPreferences();
+        }
+    }
+
+    public function fillFromPreferences(): void
+    {
+        if (!$this->preference || !$this->isPreferenceComplete($this->preference)) {
+            $this->errorMessage = 'Saved preferences are incomplete or outdated.';
+            return;
+        }
+
+        $this->shipping = $this->preference->shipping;
+        $this->payment = $this->preference->payment;
+        $this->errorMessage = '';
+    }
+
+    protected function isPreferenceComplete(UserPreference $pref): bool
+    {
+        $shipping = $pref->shipping ?? [];
+        $payment = $pref->payment ?? [];
+
+        foreach (['address', 'city', 'postal_code'] as $field) {
+            if (empty($shipping[$field])) {
+                return false;
+            }
+        }
+
+        foreach (['card_last_four', 'token'] as $field) {
+            if (empty($payment[$field])) {
+                return false;
+            }
+        }
+
+        if ($pref->updated_at && $pref->updated_at->lt(now()->subYear())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function savePreferences(): void
+    {
+        $data = $this->validate([
+            'shipping.address' => 'required|string',
+            'shipping.city' => 'required|string',
+            'shipping.postal_code' => 'required|string',
+            'payment.card_last_four' => 'required|string|size:4',
+            'payment.token' => 'required|string',
+        ]);
+
+        Auth::user()->preference()->updateOrCreate([], $data);
+        $this->errorMessage = '';
+    }
+
+    public function render()
+    {
+        return view('livewire.checkout-form');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,8 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use App\Models\UserPreference;
 
 class User extends Authenticatable
 {
@@ -44,5 +46,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function preference(): HasOne
+    {
+        return $this->hasOne(UserPreference::class);
     }
 }

--- a/app/Models/UserPreference.php
+++ b/app/Models/UserPreference.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserPreference extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'shipping',
+        'payment',
+    ];
+
+    protected $casts = [
+        'shipping' => 'encrypted:array',
+        'payment' => 'encrypted:array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2024_01_01_000003_create_user_preferences_table.php
+++ b/database/migrations/2024_01_01_000003_create_user_preferences_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->json('shipping')->nullable();
+            $table->json('payment')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_preferences');
+    }
+};

--- a/resources/views/checkout.blade.php
+++ b/resources/views/checkout.blade.php
@@ -9,6 +9,11 @@
                 <p>Your cart items will appear here.</p>
             </div>
 
+            <div class="mb-8">
+                <h3 class="text-lg font-semibold mb-2">Your Details</h3>
+                @livewire('checkout-form')
+            </div>
+
             <div class="mt-8">
                 <h3 class="text-lg font-semibold mb-2">Returns &amp; Exchanges</h3>
                 <p class="mb-2">Need to return something later? You can request a return or exchange from your <a href="{{ route('orders.index') }}" class="text-indigo-600">order history</a>.</p>

--- a/resources/views/livewire/cart-summary.blade.php
+++ b/resources/views/livewire/cart-summary.blade.php
@@ -24,4 +24,11 @@
         <button wire:click="applyCoupon($couponCode)" class="px-3 py-2 bg-blue-600 text-white rounded-r">Apply</button>
     </div>
     <x-return-policy />
+
+    <div class="mt-4 flex space-x-2">
+        <a href="{{ route('checkout') }}" class="px-4 py-2 bg-indigo-600 text-white rounded">Checkout</a>
+        @auth
+            <a href="{{ route('checkout', ['oneclick' => 1]) }}" class="px-4 py-2 bg-green-600 text-white rounded">One-Click Checkout</a>
+        @endauth
+    </div>
 </div>

--- a/resources/views/livewire/checkout-form.blade.php
+++ b/resources/views/livewire/checkout-form.blade.php
@@ -1,0 +1,35 @@
+<div class="bg-white dark:bg-gray-800 shadow rounded p-4 text-gray-800 dark:text-gray-100">
+    @if($errorMessage)
+        <div class="mb-4 text-red-600">{{ $errorMessage }}</div>
+    @endif
+
+    <div class="space-y-2">
+        <div>
+            <label class="block text-sm">Address</label>
+            <input type="text" wire:model="shipping.address" class="w-full border-gray-300 rounded" />
+        </div>
+        <div class="flex space-x-2">
+            <div class="flex-1">
+                <label class="block text-sm">City</label>
+                <input type="text" wire:model="shipping.city" class="w-full border-gray-300 rounded" />
+            </div>
+            <div class="flex-1">
+                <label class="block text-sm">Postal Code</label>
+                <input type="text" wire:model="shipping.postal_code" class="w-full border-gray-300 rounded" />
+            </div>
+        </div>
+        <div>
+            <label class="block text-sm">Card Last Four</label>
+            <input type="text" wire:model="payment.card_last_four" class="w-full border-gray-300 rounded" />
+        </div>
+        <div>
+            <label class="block text-sm">Payment Token</label>
+            <input type="text" wire:model="payment.token" class="w-full border-gray-300 rounded" />
+        </div>
+    </div>
+
+    <div class="mt-4 flex space-x-2">
+        <button type="button" wire:click="fillFromPreferences" class="px-4 py-2 bg-green-600 text-white rounded">One-Click Checkout</button>
+        <button type="button" wire:click="savePreferences" class="px-4 py-2 bg-blue-600 text-white rounded">Save Preferences</button>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,9 @@ Route::view('profile', 'profile')
     ->middleware(['auth'])
     ->name('profile');
 
-Route::view('checkout', 'checkout')->name('checkout');
+Route::view('checkout', 'checkout')
+    ->middleware(['auth'])
+    ->name('checkout');
 
 Route::view('orders', 'orders')
     ->middleware(['auth'])


### PR DESCRIPTION
## Summary
- store encrypted shipping/payment preferences in new `user_preferences` table
- add Livewire checkout form with one-click autofill and validation
- expose one-click checkout link from cart summary and protect checkout route

## Testing
- `composer test` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b1734a1f58832e896320c8b544d817