### PR TITLE
Add upsell-aware cart summary component and cart page

### DIFF
--- a/app/Livewire/CartSummary.php
+++ b/app/Livewire/CartSummary.php
@@ -13,16 +13,35 @@ class CartSummary extends Component
     public ?array $coupon = null;
     public string $couponCode = '';
 
+    /**
+     * Basic product catalog for upsell recommendations.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    protected array $catalog = [];
+
     protected $listeners = ['addToCart' => 'add', 'applyCoupon' => 'applyCoupon'];
 
-    public function mount()
+    public function mount(): void
     {
+        $this->catalog = [
+            ['id' => 1, 'slug' => 'espresso', 'name' => 'Espresso', 'price' => 3.50, 'image' => 'https://source.unsplash.com/random/300x300?espresso', 'category' => 'coffee'],
+            ['id' => 2, 'slug' => 'cappuccino', 'name' => 'Cappuccino', 'price' => 4.25, 'image' => 'https://source.unsplash.com/random/300x300?cappuccino', 'category' => 'coffee'],
+            ['id' => 3, 'slug' => 'latte', 'name' => 'Latte', 'price' => 4.75, 'image' => 'https://source.unsplash.com/random/300x300?latte', 'category' => 'coffee'],
+            ['id' => 4, 'slug' => 'mocha', 'name' => 'Mocha', 'price' => 5.00, 'image' => 'https://source.unsplash.com/random/300x300?mocha', 'category' => 'coffee'],
+            ['id' => 5, 'slug' => 'green-tea', 'name' => 'Green Tea', 'price' => 2.50, 'image' => 'https://source.unsplash.com/random/300x300?greentea', 'category' => 'tea'],
+            ['id' => 6, 'slug' => 'black-tea', 'name' => 'Black Tea', 'price' => 2.75, 'image' => 'https://source.unsplash.com/random/300x300?blacktea', 'category' => 'tea'],
+            ['id' => 7, 'slug' => 'french-press', 'name' => 'French Press', 'price' => 25.00, 'image' => 'https://source.unsplash.com/random/300x300?frenchpress', 'category' => 'equipment'],
+            ['id' => 8, 'slug' => 'coffee-grinder', 'name' => 'Coffee Grinder', 'price' => 45.00, 'image' => 'https://source.unsplash.com/random/300x300?grinder', 'category' => 'equipment'],
+        ];
+
         $this->recalculate();
     }
 
     public function add(array $product): void
     {
         $id = $product['id'];
+        $catalogItem = collect($this->catalog)->firstWhere('id', $id);
         if (isset($this->cart[$id])) {
             $this->cart[$id]['qty']++;
         } else {
@@ -31,6 +50,7 @@ class CartSummary extends Component
                 'name' => $product['name'],
                 'price' => $product['price'],
                 'qty' => 1,
+                'category' => $catalogItem['category'] ?? null,
             ];
         }
 
@@ -55,6 +75,25 @@ class CartSummary extends Component
     {
         $discount = $this->coupon['discount'] ?? 0;
         return round($this->subtotal - ($this->subtotal * $discount) + $this->shipping, 2);
+    }
+
+    public function getCouponSavingsProperty(): float
+    {
+        $discount = $this->coupon['discount'] ?? 0;
+        return round($this->subtotal * $discount, 2);
+    }
+
+    public function getUpsellItemsProperty(): array
+    {
+        $cartIds = array_keys($this->cart);
+        $categories = collect($this->cart)->pluck('category')->filter()->unique()->all();
+
+        return collect($this->catalog)
+            ->whereIn('category', $categories)
+            ->whereNotIn('id', $cartIds)
+            ->take(3)
+            ->values()
+            ->all();
     }
 
     public function render()

--- a/resources/views/cart.blade.php
+++ b/resources/views/cart.blade.php
@@ -1,0 +1,8 @@
+<x-app-layout>
+    <div class="py-8">
+        <div class="max-w-3xl mx-auto px-4">
+            <h2 class="text-2xl font-semibold mb-4">Your Cart</h2>
+            <livewire:cart-summary />
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -24,7 +24,7 @@
         </div>
     </div>
 
-    <div class="fixed bottom-6 right-6 w-80">
+    <div class="fixed bottom-6 right-6 w-96">
         <livewire:cart-summary />
     </div>
 

--- a/resources/views/livewire/cart-summary.blade.php
+++ b/resources/views/livewire/cart-summary.blade.php
@@ -12,9 +12,9 @@
     </ul>
     <div class="mt-4 border-t pt-2 text-sm space-y-1">
         <div class="flex justify-between"><span>Subtotal</span><span>${{ number_format($subtotal,2) }}</span></div>
-        <div class="flex justify-between"><span>Shipping</span><span>${{ number_format($shipping,2) }}</span></div>
+        <div class="flex justify-between"><span>Shipping Estimate</span><span>${{ number_format($shipping,2) }}</span></div>
         @if($coupon)
-            <div class="flex justify-between text-green-600"><span>Coupon ({{ $coupon['code'] }})</span><span>-{{ $coupon['discount'] * 100 }}%</span></div>
+            <div class="flex justify-between text-green-600"><span>Coupon ({{ $coupon['code'] }})</span><span>- ${{ number_format($this->couponSavings,2) }}</span></div>
         @endif
         <div class="flex justify-between font-semibold"><span>Total</span><span>${{ number_format($this->total,2) }}</span></div>
         <div class="mt-2 text-xs text-gray-500">Loyalty points: {{ $loyaltyPoints }}</div>
@@ -23,6 +23,20 @@
         <input type="text" wire:model.defer="couponCode" placeholder="Coupon code" class="flex-1 rounded-l border-gray-300" />
         <button wire:click="applyCoupon($couponCode)" class="px-3 py-2 bg-blue-600 text-white rounded-r">Apply</button>
     </div>
+    @if($this->upsellItems)
+        <div class="mt-4 border-t pt-2">
+            <h4 class="text-sm font-semibold mb-2">You might also like</h4>
+            <ul class="space-y-1 text-sm">
+                @foreach($this->upsellItems as $item)
+                    <li class="flex justify-between">
+                        <span>{{ $item['name'] }}</span>
+                        <button onclick="Livewire.dispatch('addToCart', {id: {{ $item['id'] }}, name: '{{ $item['name'] }}', price: {{ $item['price'] }} })" class="text-blue-600">Add ${{ number_format($item['price'],2) }}</button>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
     <x-return-policy />
 
     <div class="mt-4 flex space-x-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,8 @@ Route::view('checkout', 'checkout')
     ->middleware(['auth'])
     ->name('checkout');
 
+Route::view('cart', 'cart')->name('cart');
+
 Route::view('orders', 'orders')
     ->middleware(['auth'])
     ->name('orders.index');


### PR DESCRIPTION
## Summary
- extend cart summary Livewire component with coupon savings, shipping estimates, and upsell recommendations
- show cart summary on home and new cart page
- register new `/cart` route

## Testing
- `composer install`
- `php artisan test` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b17439d09c832e95000676916b303a