### PR TITLE
Add exit intent discount modal with session logging

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 Route::view('/', 'home')->name('home');
 
@@ -33,5 +35,14 @@ Route::view('orders', 'orders')
 Route::get('orders/{order}/return', function (string $order) {
     return view('returns', ['order' => $order]);
 })->middleware(['auth'])->name('orders.return');
+
+Route::post('/exit-intent', function (Request $request) {
+    Log::info('Exit intent response', [
+        'action' => $request->input('action'),
+        'user_id' => auth()->id(),
+        'session_id' => $request->session()->getId(),
+    ]);
+    return response()->json(['status' => 'ok']);
+})->name('exit-intent');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- show exit-intent modal on homepage with personalized discount
- track dismiss/claim actions and show only once per session
- log modal interactions via new `/exit-intent` endpoint

## Testing
- `php artisan test` *(fails: Database file at path [testing] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b1752bbd74832e9c24b4bf610e8a2f